### PR TITLE
ESP8266 compatibility, faster data readout, and general improvements

### DIFF
--- a/src/SparkFun_MAG3110.cpp
+++ b/src/SparkFun_MAG3110.cpp
@@ -316,6 +316,6 @@ int MAG3110::readAxis(uint8_t axis){
 	
 	lsb = readRegister(lsbAddress);
 	
-	int out = (lsb | (msb << 8)); //concatenate the MSB and LSB
-	return out;
+	int16_t out = (lsb | (msb << 8)); //concatenate the MSB and LSB;
+	return (int)out;
 }

--- a/src/SparkFun_MAG3110.cpp
+++ b/src/SparkFun_MAG3110.cpp
@@ -109,10 +109,14 @@ void MAG3110::readMag(int* x, int* y, int* z){
 
 void MAG3110::readMicroTeslas(float* x, float* y, float* z){
 	
+	// Using internal read function
+	int x_int, y_int, z_int;
+	readMag(&x_int, &y_int, &z_int);
+
 	//Read each axis and scale to Teslas
-	*x = (float) readAxis(MAG3110_OUT_X_MSB) * 0.1f;
-	*y = (float) readAxis(MAG3110_OUT_Y_MSB) * 0.1f;
-	*z = (float) readAxis(MAG3110_OUT_Z_MSB) * 0.1f;
+	*x = (float) x_int * 0.1f;
+	*y = (float) y_int * 0.1f;
+	*z = (float) z_int * 0.1f;
 	
 }
 

--- a/src/SparkFun_MAG3110.cpp
+++ b/src/SparkFun_MAG3110.cpp
@@ -80,10 +80,31 @@ bool MAG3110::dataReady() {
 }
 
 void MAG3110::readMag(int* x, int* y, int* z){
-	//Read each axis
-	*x = readAxis(MAG3110_OUT_X_MSB);
-	*y = readAxis(MAG3110_OUT_Y_MSB);
-	*z = readAxis(MAG3110_OUT_Z_MSB);
+
+	// Start readout at X MSB address
+	Wire.beginTransmission(MAG3110_I2C_ADDRESS);
+	Wire.write(MAG3110_OUT_X_MSB);
+	Wire.endTransmission();
+
+	delayMicroseconds(2);
+
+	// Read out data using multiple byte read mode
+	Wire.requestFrom(MAG3110_I2C_ADDRESS, 6);
+ 	while( Wire.available() != 6 ) {}
+
+ 	// Combine registers
+	uint16_t values[3];
+	for(uint8_t idx = 0; idx <= 2; idx++)
+	{
+		values[idx]  = Wire.read() << 8;	// MSB
+		values[idx] |= Wire.read();			// LSB
+	}
+
+	// Put data into referenced variables
+	*x = (int) values[0];
+	*y = (int) values[1];
+	*z = (int) values[2];
+
 }
 
 void MAG3110::readMicroTeslas(float* x, float* y, float* z){

--- a/src/SparkFun_MAG3110.cpp
+++ b/src/SparkFun_MAG3110.cpp
@@ -40,7 +40,6 @@ bool MAG3110::initialize() {
 	Wire.setClock(400000);		// I2C fast mode, 400kHz
 	if(readRegister(MAG3110_WHO_AM_I) != MAG3110_WHO_AM_I_RSP){ //Could not find MAG3110
 		//Serial.println("Could not find MAG3110 connected!");
-		error = true;
 		return false;
 	}
 	else //Successfully initialized

--- a/src/SparkFun_MAG3110.cpp
+++ b/src/SparkFun_MAG3110.cpp
@@ -35,16 +35,18 @@ MAG3110::MAG3110() {
 	y_scale = 0.0f;
 }
 
-void MAG3110::initialize() {
+bool MAG3110::initialize() {
 	Wire.begin();
 	if(readRegister(MAG3110_WHO_AM_I) != MAG3110_WHO_AM_I_RSP){ //Could not find MAG3110
 		//Serial.println("Could not find MAG3110 connected!");
 		error = true;
+		return false;
 	}
 	else //Successfully initialized
 	{
 		//Initial values
 		reset();
+		return true;
 	}
 }
 

--- a/src/SparkFun_MAG3110.cpp
+++ b/src/SparkFun_MAG3110.cpp
@@ -37,6 +37,7 @@ MAG3110::MAG3110() {
 
 bool MAG3110::initialize() {
 	Wire.begin();
+	Wire.setClock(400000);		// I2C fast mode, 400kHz
 	if(readRegister(MAG3110_WHO_AM_I) != MAG3110_WHO_AM_I_RSP){ //Could not find MAG3110
 		//Serial.println("Could not find MAG3110 connected!");
 		error = true;

--- a/src/SparkFun_MAG3110.h
+++ b/src/SparkFun_MAG3110.h
@@ -123,7 +123,7 @@ class MAG3110
  public:
   MAG3110();
   
-  void initialize();
+  bool initialize();
   
   //Public methods
   uint8_t readRegister(uint8_t address);


### PR DESCRIPTION
This pull request includes four improvements to this library:
1. It is now compatible with the ESP8266.  The contents of commit [5171152](https://github.com/Ductapemaster/SparkFun_MAG3110_Breakout_Board_Arduino_Library/commit/5171152f219c2cc9d2a03343c1491cc809085fc4) contain this change.  The combined register values had to be cast as a `uint16_t`, as the size of `int` on the ESP8266 is different from other 8-bit Arduinos.
2. the `initialize()` function in the library now returns a boolean value that represents whether or not it was successful.  Previously, a user had no idea if the MAG3110 was detected and reset.  Relevant commits: [7517929](https://github.com/Ductapemaster/SparkFun_MAG3110_Breakout_Board_Arduino_Library/commit/75179299637c9c0b989de1d4d96fd49357a8d349) and [dd38334](https://github.com/Ductapemaster/SparkFun_MAG3110_Breakout_Board_Arduino_Library/commit/dd38334df3e0622af929fdc0b30c136774d79ca0)
3. The MAG3110 support Fast Mode (400kHz) I2C communication.  This has been enabled in the library.  The change is included in commit [ecd3b88](https://github.com/Ductapemaster/SparkFun_MAG3110_Breakout_Board_Arduino_Library/commit/ecd3b8879448d24fc9df28fba3733126a55137a6)
4. The `readMag()` function now uses the Multiple Byte Read mode mentioned in the datasheet on page 12 instead of reading single bytes for each register to generate the X, Y, and Z values.  Additionally, the `readMicroTeslas()` function now uses the new, faster `readMag()` function internally to grab the data before casting to floats and scaling.  Commits [20878e5](https://github.com/Ductapemaster/SparkFun_MAG3110_Breakout_Board_Arduino_Library/commit/20878e58b269adda3c7703e51505c68eb88df55e) and [d2e0b1b](https://github.com/Ductapemaster/SparkFun_MAG3110_Breakout_Board_Arduino_Library/commit/d2e0b1b64d11fac684926b38ccb400cc29d3e451) contain these changes.

Improvements 3 and 4 combined added up to nearly a 10x speedup of communications with the MAG3110 from my test ESP8266.  The calls to the new readMag() time approximately 290us, down from approximately 2900us with the original 100kHz I2C and single byte read mode implementation.

Hopefully these are useful improvements.  I'm happy to explain further if needed.